### PR TITLE
Automate CLI documentation

### DIFF
--- a/.github/workflows/check-readme-cli.yaml
+++ b/.github/workflows/check-readme-cli.yaml
@@ -1,0 +1,30 @@
+name: Check README CLI is consistent with docs
+run-name: Check README CLI is consistent with docs
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check-readme-cli:
+    if: >
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request'
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Regenerate CLI help
+        run: python docs/cli/generate-cli.py
+
+      - name: Check README section matches cli-help.md
+        run: python docs/cli/check-readme.py

--- a/.github/workflows/check-readme-cli.yaml
+++ b/.github/workflows/check-readme-cli.yaml
@@ -7,13 +7,7 @@ on:
 
 jobs:
   check-readme-cli:
-    if: >
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'pull_request'
-      }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/check-readme-cli.yaml
+++ b/.github/workflows/check-readme-cli.yaml
@@ -12,13 +12,20 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: "3.12"
+          enable-cache: true
+
+      - name: Create uv virtualenv
+        run: uv venv
+
+      - name: Install package (as need to run lintquarto --help!)
+        run: uv pip install .
 
       - name: Regenerate CLI help
-        run: python docs/cli/generate-cli.py
+        run: uv run python docs/cli/generate-cli.py
 
       - name: Check README section matches cli-help.md
-        run: python docs/cli/check-readme.py
+        run: uv run python docs/cli/check-readme.py

--- a/README.md
+++ b/README.md
@@ -81,21 +81,28 @@ pip install -e ".[all]"
 
 ### Usage
 
+<!-- cli-help:start -->
 Usage:
 
 ```
-lintquarto -l LINTER [LINTER ...] -p PATH [PATH ...] [-e EXCLUDE [EXCLUDE ...]] [-k] [-n]
+lintquarto [-h] -l LINTER [LINTER ...] -p PATHS [PATHS ...] [-e [[exclude_paths] ...]] [-n] [-v] [-k]
 ```
+
+Lint Python code in Quarto (.qmd) files.
 
 Options:
 
-* `-l, --linters LINTER [LINTER ...]` - linters to run.
-* `-p, --paths PATH [PATH ...]` - quarto files and/or directories to include.
-* `-e, --exclude EXCLUDE [EXCLUDE ...]` - optional, files and/or directories to exclude.
-* `-k, --keep-temp` - optional, keep temporary `.py` files created during linting (for debugging).
-* `-n, --lint-non-exec` - optional, opt-in to also run tools on non-executable cells.
+* `-h, --help` - show this help message and exit
+* `-l LINTER [LINTER ...], --linters LINTER [LINTER ...]` - Linters to run. Valid options: ['flake8', 'mypy', 'pycodestyle', 'pydoclint', 'pyflakes', 'pylint', 'pyright', 'pyrefly', 'pytype', 'radon-cc', 'radon- mi', 'radon-raw', 'radon-hal', 'ruff', 'vulture']
+* `-p PATHS [PATHS ...], --paths PATHS [PATHS ...]` - Quarto files and/or directories to lint.
+* `-e [[exclude_paths] ...], --exclude [[exclude_paths] ...]` - Files and/or directories to exclude from linting.
+* `-n, --lint-non-exec` - Also lint non-executable Python code chunks
+* `-v, --verbose` - Verbose output.
+* `-k, --keep-temp` - Keep temporary .py files after linting.
 
-Passing extra arguments directly to linters is not supported. Only `.qmd` files are processed.
+Passing extra arguments directly to linters is not supported.
+Only `.qmd` files are processed.
+<!-- cli-help:end -->
 
 ### Examples
 

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -1,6 +1,7 @@
 project:
   type: website
   output-dir: _site
+  pre-render: python cli/generate-cli.py
   render:
   - "*.qmd"
   - "!pages/tools/examples"

--- a/docs/cli/check-readme.py
+++ b/docs/cli/check-readme.py
@@ -1,0 +1,26 @@
+"""Check cli-help.md is consistent with README.md."""
+
+import re
+import sys
+from pathlib import Path
+
+readme = Path("README.md").read_text(encoding="utf-8")
+cli_help = Path("docs/cli/cli-help.md").read_text(encoding="utf-8").strip()
+
+match = re.search(
+    r"<!-- cli-help:start -->\n(.*?)\n<!-- cli-help:end -->",
+    readme,
+    re.DOTALL,
+)
+
+if not match:
+    print("Could not find README markers.")
+    sys.exit(1)
+
+readme_section = match.group(1).strip()
+
+if readme_section != cli_help:
+    print("README CLI help section is out of date.")
+    sys.exit(1)
+
+print("README CLI help section is up to date.")

--- a/docs/cli/cli-help.md
+++ b/docs/cli/cli-help.md
@@ -1,0 +1,20 @@
+Usage:
+
+```
+lintquarto [-h] -l LINTER [LINTER ...] -p PATHS [PATHS ...] [-e [[exclude_paths] ...]] [-n] [-v] [-k]
+```
+
+Lint Python code in Quarto (.qmd) files.
+
+Options:
+
+* `-h, --help` - show this help message and exit
+* `-l LINTER [LINTER ...], --linters LINTER [LINTER ...]` - Linters to run. Valid options: ['flake8', 'mypy', 'pycodestyle', 'pydoclint', 'pyflakes', 'pylint', 'pyright', 'pyrefly', 'pytype', 'radon-cc', 'radon- mi', 'radon-raw', 'radon-hal', 'ruff', 'vulture']
+* `-p PATHS [PATHS ...], --paths PATHS [PATHS ...]` - Quarto files and/or directories to lint.
+* `-e [[exclude_paths] ...], --exclude [[exclude_paths] ...]` - Files and/or directories to exclude from linting.
+* `-n, --lint-non-exec` - Also lint non-executable Python code chunks
+* `-v, --verbose` - Verbose output.
+* `-k, --keep-temp` - Keep temporary .py files after linting.
+
+Passing extra arguments directly to linters is not supported.
+Only `.qmd` files are processed.

--- a/docs/cli/generate-cli.py
+++ b/docs/cli/generate-cli.py
@@ -1,0 +1,115 @@
+"""Generate markdown formatted CLI documentation."""
+
+import re
+import subprocess
+from pathlib import Path
+
+# Output file where the generated CLI help documentation will be saved
+TARGET = Path(__file__).parent / "cli-help.md"
+
+# Run the CLI command and capture its help output
+help_text = subprocess.run(
+    ["lintquarto", "--help"],  # noqa: S607
+    capture_output=True,
+    text=True,
+    check=True,
+).stdout.rstrip()
+
+# Split help output into lines for parsing
+lines = help_text.splitlines()
+
+# Storage for parsed sections
+usage_lines = []
+options = []
+description_lines = []
+
+in_usage = False
+in_options = False
+current_flag = None
+current_desc = []
+
+for line in lines:
+    stripped = line.rstrip()
+
+    # Start usage block
+    if line.startswith("usage:"):
+        in_usage = True
+        usage_lines.append(line.removeprefix("usage:").strip())
+        continue
+
+    # Continue wrapped usage lines until a blank line or a new section
+    if in_usage:
+        if not line.strip():
+            in_usage = False
+            continue
+        if line.strip() == "options:":
+            in_usage = False
+            in_options = True
+            continue
+        if line.startswith(" "):
+            usage_lines.append(line.strip())
+            continue
+        else:
+            in_usage = False
+
+    # Capture description text between usage and options
+    if not in_options and line.strip() and line.strip() != "options:":
+        description_lines.append(line.strip())
+        continue
+
+    # Detect start of options section
+    if line.strip() == "options:":
+        in_options = True
+        continue
+
+    # Ignore anything outside options from here on
+    if not in_options or not line.strip():
+        continue
+
+    # Detect a new option entry
+    if re.match(r"^\s+-", stripped):
+        if current_flag is not None:
+            options.append((current_flag, " ".join(current_desc).strip()))
+
+        match = re.match(r"^\s*(.+?)(?:\s{2,}(.+))?$", stripped)
+        current_flag = match.group(1).strip()
+        first_desc = match.group(2).strip() if match.group(2) else ""
+        current_desc = [first_desc] if first_desc else []
+    else:
+        # Continuation line for a multi-line option description
+        current_desc.append(stripped.strip())
+
+# Save final option
+if current_flag is not None:
+    options.append((current_flag, " ".join(current_desc).strip()))
+
+# Join wrapped usage back into one line
+usage = " ".join(usage_lines)
+
+# Format options as Markdown bullets
+formatted_options = [
+    f"* `{flag}` - {desc}" if desc else f"* `{flag}`" for flag, desc in options
+]
+
+# Build final Markdown output
+output = "\n".join(
+    [
+        "Usage:",
+        "",
+        "```",
+        usage,
+        "```",
+        "",
+        *description_lines,
+        "",
+        "Options:",
+        "",
+        *formatted_options,
+        "",
+        "Passing extra arguments directly to linters is not supported.",
+        "Only `.qmd` files are processed.",
+    ]
+)
+
+# Write output to file
+TARGET.write_text(output, encoding="utf-8")

--- a/docs/pages/get_started.qmd
+++ b/docs/pages/get_started.qmd
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+jupyter: python3
 ---
 
 ## Installation
@@ -62,21 +63,15 @@ pip install -e ".[all]"
 
 ## Basic usage
 
-Usage:
+```{python}
+#| echo: false
+#| output: asis
 
+from pathlib import Path
+
+output = Path("../cli/cli-help.md").read_text(encoding="utf-8")
+print(output)
 ```
-lintquarto -l LINTER [LINTER ...] -p PATH [PATH ...] [-e EXCLUDE [EXCLUDE ...]] [-k] [-n]
-```
-
-Options:
-
-* `-l, --linters LINTER [LINTER ...]` - linters to run.
-* `-p, --paths PATH [PATH ...]` - quarto files and/or directories to include.
-* `-e, --exclude EXCLUDE [EXCLUDE ...]` - optional, files and/or directories to exclude.
-* `-k, --keep-temp` - optional, keep temporary `.py` files created during linting (for debugging).
-* `-n, --lint-non-exec` - optional, opt-in to also run tools on non-executable cells.
-
-Passing extra arguments directly to linters is not supported. Only `.qmd` files are processed.
 
 <br>
 


### PR DESCRIPTION
Could've gone real simple, just outputting the text output of `lintquarto --help`, but decided wanted to alter it to look nice in markdown.

Fixes #130.